### PR TITLE
Set update events in the resolver to not be queued, as they are only dispatched when the given component's queue is empty and should be processed immediately.

### DIFF
--- a/src/services/resolver.js
+++ b/src/services/resolver.js
@@ -101,7 +101,7 @@ define( function ( require ) {
 
     this.world.SetGravity(newGravity);
     // Update all physics components
-    var updateEvent = new Event( 'Update', false );
+    var updateEvent = new Event( 'Update', undefined, false );
     for( var componentType in registeredComponents ) {
       for( entityId in registeredComponents[componentType] ) {
         component = registeredComponents[componentType][entityId];


### PR DESCRIPTION
Defect #10
